### PR TITLE
Fix Docker Compose deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ services:
       JWT_EXPIRES_IN: 7d
       GOOGLE_CLIENT_ID: your_google_client_id
       GOOGLE_CLIENT_SECRET: your_google_client_secret
-      GOOGLE_CALLBACK_URL: http://localhost:5000/auth/google/callback
+      GOOGLE_CALLBACK_URL: http://localhost/auth/google/callback
       FRONTEND_URL: http://localhost
     ports:
       - "5000:5000"
@@ -119,8 +119,6 @@ services:
   frontend:
     image: ghcr.io/ndsrf/regalo-anonimo-familiar/frontend:latest
     container_name: secret-wishlist-frontend
-    environment:
-      VITE_API_URL: http://localhost:5000
     ports:
       - "80:80"
     depends_on:
@@ -160,6 +158,16 @@ networks:
     driver: bridge
 ```
 
+**Important Notes:**
+
+- **API Proxy Configuration**: The frontend uses nginx as a reverse proxy. All requests to `/api/*` and `/auth/*` are automatically forwarded to the backend container. This means:
+  - The frontend doesn't need to know the backend URL
+  - No CORS configuration needed between services
+  - The application works seamlessly when accessed from any domain
+  - If deploying to a custom domain (e.g., `https://yourdomain.com`), update both `GOOGLE_CALLBACK_URL` and `FRONTEND_URL` accordingly
+
+- **Backend Port Exposure**: The backend port `5000` is exposed for direct access if needed, but the frontend communicates with it through the nginx proxy on port 80.
+
 #### Watchtower - Automatic Container Updates
 
 The docker-compose configuration includes **Watchtower**, which automatically updates your containers when new images are available in GitHub Container Registry.
@@ -187,7 +195,7 @@ Before running docker-compose, make sure to update the following values in the `
 3. **Google OAuth Credentials**:
    - Replace `your_google_client_id` with your Google OAuth Client ID
    - Replace `your_google_client_secret` with your Google OAuth Client Secret
-   - Update `GOOGLE_CALLBACK_URL` if deploying to a different domain
+   - Update `GOOGLE_CALLBACK_URL` and `FRONTEND_URL` if deploying to a different domain (e.g., `https://yourdomain.com/auth/google/callback`)
 4. **Timezone (Optional)**: Update `TZ` in the watchtower service to match your timezone (default: Europe/Madrid)
 
 #### Running the Application
@@ -219,7 +227,8 @@ docker compose down -v
 
 The application will be accessible at:
 - **Frontend**: http://localhost
-- **Backend API**: http://localhost:5000
+- **Backend API** (via nginx proxy): http://localhost/api
+- **Backend API** (direct): http://localhost:5000
 - **PostgreSQL**: localhost:5432
 
 ### Building Images Locally

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -15,6 +15,32 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
+    # Proxy API requests to backend
+    location /api/ {
+        proxy_pass http://backend:5000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    # Proxy auth requests to backend
+    location /auth/ {
+        proxy_pass http://backend:5000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+
     # Handle client-side routing
     location / {
         try_files $uri $uri/ /index.html;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+const API_URL = import.meta.env.VITE_API_URL || '';
 
 const api = axios.create({
   baseURL: API_URL,
@@ -41,7 +41,8 @@ export const authAPI = {
   login: (data) => api.post('/auth/login', data),
   getMe: () => api.get('/auth/me'),
   googleLogin: () => {
-    window.location.href = `${API_URL}/auth/google`;
+    const url = API_URL ? `${API_URL}/auth/google` : '/auth/google';
+    window.location.href = url;
   },
 };
 


### PR DESCRIPTION
- Configure nginx reverse proxy to forward /api and /auth requests to backend container
- Update frontend to use relative URLs instead of hardcoded localhost:5000
- Remove VITE_API_URL environment variable from docker-compose.yml (not needed with proxy)
- Update GOOGLE_CALLBACK_URL to use proxied path (http://localhost/auth/google/callback)
- Add documentation explaining the nginx proxy configuration and deployment setup

This fixes ERR_CONNECTION_REFUSED errors when accessing the backend API from the browser. The frontend now communicates with the backend through the nginx reverse proxy, eliminating CORS issues and ensuring seamless operation regardless of the deployment domain.