### PR TITLE
Fix infinite loop on browse page

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -52,9 +52,22 @@ export const AuthProvider = ({ children }) => {
     setUser(null);
   };
 
-  const handleGoogleCallback = (tokenFromUrl) => {
+  const handleGoogleCallback = async (tokenFromUrl) => {
     localStorage.setItem('token', tokenFromUrl);
     setToken(tokenFromUrl);
+
+    // Load user data immediately to avoid race conditions
+    try {
+      const response = await authAPI.getMe();
+      setUser(response.data.user);
+      setLoading(false);
+      return true; // Success
+    } catch (error) {
+      console.error('Failed to load user after Google callback:', error);
+      logout();
+      setLoading(false);
+      return false; // Failure
+    }
   };
 
   return (

--- a/frontend/src/pages/GoogleCallback.jsx
+++ b/frontend/src/pages/GoogleCallback.jsx
@@ -8,17 +8,26 @@ export default function GoogleCallback() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const token = searchParams.get('token');
-    const error = searchParams.get('error');
+    const processCallback = async () => {
+      const token = searchParams.get('token');
+      const error = searchParams.get('error');
 
-    if (token) {
-      handleGoogleCallback(token);
-      navigate('/groups');
-    } else if (error) {
-      alert('Error al iniciar sesión con Google');
-      navigate('/login');
-    }
-  }, [searchParams]);
+      if (token) {
+        // Wait for user to be loaded before navigating
+        const success = await handleGoogleCallback(token);
+        if (success) {
+          navigate('/groups');
+        } else {
+          navigate('/login');
+        }
+      } else if (error) {
+        alert('Error al iniciar sesión con Google');
+        navigate('/login');
+      }
+    };
+
+    processCallback();
+  }, [searchParams, handleGoogleCallback, navigate]);
 
   return (
     <div className="min-h-screen flex items-center justify-center">

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -28,8 +28,9 @@ api.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
+      // Let AuthContext handle logout and redirect
+      // Don't use hard redirect here to avoid breaking React state
       localStorage.removeItem('token');
-      window.location.href = '/login';
     }
     return Promise.reject(error);
   }


### PR DESCRIPTION
This commit resolves a critical infinite loop issue where users would get stuck in a redirect loop between the home page and authentication page.

Root causes fixed:
1. API interceptor: Removed hard redirect (window.location.href) on 401 errors
   - Hard redirects bypass React state and cause full page reloads
   - Now only clears localStorage and lets React Router handle navigation

2. GoogleCallback race condition: Made handleGoogleCallback async
   - Previously only set token without loading user data
   - Now waits for user data to load before returning control
   - Returns success/failure status for proper error handling

3. GoogleCallback navigation timing: Wait for user load before redirect
   - Previously navigated to /groups immediately after setting token
   - Now waits for handleGoogleCallback to complete and load user
   - Only navigates after user is authenticated to avoid ProtectedRoute redirect

4. Fixed useEffect dependencies in GoogleCallback
   - Added missing dependencies: handleGoogleCallback, navigate
   - Follows React best practices and prevents stale closures

These changes ensure proper authentication flow with no race conditions.