### PR TITLE
Fix Watchtower container update issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ services:
       timeout: 3s
       retries: 3
       start_period: 10s
+    restart: unless-stopped
     networks:
       - wishlist-network
     labels:
@@ -139,6 +140,7 @@ services:
       timeout: 3s
       retries: 3
       start_period: 5s
+    restart: unless-stopped
     networks:
       - wishlist-network
     labels:
@@ -152,6 +154,7 @@ services:
       WATCHTOWER_LABEL_ENABLE: "true"
       WATCHTOWER_INCLUDE_RESTARTING: "true"
       WATCHTOWER_POLL_INTERVAL: 300
+      WATCHTOWER_ROLLING_RESTART: "true"
       TZ: Europe/Madrid
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -187,6 +190,7 @@ The docker-compose configuration includes **Watchtower**, which automatically up
 - **WATCHTOWER_LABEL_ENABLE**: Only monitors containers with the `com.centurylinklabs.watchtower.enable=true` label
 - **WATCHTOWER_POLL_INTERVAL**: Checks for updates every 300 seconds (5 minutes)
 - **WATCHTOWER_INCLUDE_RESTARTING**: Updates containers even if they're restarting
+- **WATCHTOWER_ROLLING_RESTART**: Updates containers one at a time to ensure service availability
 
 All application containers (postgres, backend, frontend) are labeled for automatic updates. When new images are pushed to GHCR via GitHub Actions, Watchtower will:
 1. Pull the new image
@@ -195,6 +199,8 @@ All application containers (postgres, backend, frontend) are labeled for automat
 4. Remove the old image
 
 This ensures your deployment always runs the latest version without manual intervention.
+
+**Note on Container Updates**: The frontend uses nginx with Docker's internal DNS resolver, which allows it to start even if the backend is temporarily unavailable during updates. Combined with restart policies (`restart: unless-stopped`), this ensures the application recovers automatically from transient failures during Watchtower updates.
 
 #### Environment Variables Setup
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,11 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Use Docker's internal DNS server for runtime hostname resolution
+    # This prevents nginx from failing if backend is not available at startup
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    resolver_timeout 5s;
+
     # Gzip compression
     gzip on;
     gzip_vary on;
@@ -17,7 +22,9 @@ server {
 
     # Proxy API requests to backend
     location /api/ {
-        proxy_pass http://backend:5000;
+        # Use variable to force runtime DNS resolution
+        set $backend_upstream backend:5000;
+        proxy_pass http://$backend_upstream;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -30,7 +37,9 @@ server {
 
     # Proxy auth requests to backend
     location /auth/ {
-        proxy_pass http://backend:5000;
+        # Use variable to force runtime DNS resolution
+        set $backend_upstream backend:5000;
+        proxy_pass http://$backend_upstream;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
When Watchtower updates containers, it recreates them in a sequence that sometimes causes the frontend to start before the backend is available on the Docker network. This caused nginx to fail with "host not found in upstream 'backend'" because nginx resolves hostnames at startup by default.

Changes:
- Configure nginx to use Docker's internal DNS resolver (127.0.0.11)
- Use variables in proxy_pass to force runtime DNS resolution
- Add restart policies to backend and frontend containers
- Enable WATCHTOWER_ROLLING_RESTART for one-at-a-time updates
- Document the fix in README.md

This ensures nginx can start even if the backend is temporarily unavailable, and the application will recover automatically during Watchtower updates.