### PR TITLE
Fix group join flow to preserve invite context through authentication

### DIFF
--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,8 +1,9 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 export default function ProtectedRoute({ children }) {
   const { isAuthenticated, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) {
     return (
@@ -16,7 +17,9 @@ export default function ProtectedRoute({ children }) {
   }
 
   if (!isAuthenticated) {
-    return <Navigate to="/login" replace />;
+    // Preserve the current location so we can redirect back after login
+    const returnTo = encodeURIComponent(location.pathname + location.search);
+    return <Navigate to={`/login?returnTo=${returnTo}`} replace />;
   }
 
   return children;

--- a/frontend/src/pages/GoogleCallback.jsx
+++ b/frontend/src/pages/GoogleCallback.jsx
@@ -16,7 +16,14 @@ export default function GoogleCallback() {
         // Wait for user to be loaded before navigating
         const success = await handleGoogleCallback(token);
         if (success) {
-          navigate('/groups');
+          // Check for returnTo in sessionStorage
+          const returnTo = sessionStorage.getItem('returnTo');
+          if (returnTo) {
+            sessionStorage.removeItem('returnTo');
+            navigate(decodeURIComponent(returnTo));
+          } else {
+            navigate('/groups');
+          }
         } else {
           navigate('/login');
         }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { authAPI } from '../services/api';
 
@@ -10,6 +10,10 @@ export default function Login() {
   const [loading, setLoading] = useState(false);
   const { login } = useAuth();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  // Get the return URL from query params
+  const returnTo = searchParams.get('returnTo');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -18,7 +22,9 @@ export default function Login() {
 
     try {
       await login({ email, password });
-      navigate('/groups');
+      // Redirect to returnTo if available, otherwise to /groups
+      const destination = returnTo ? decodeURIComponent(returnTo) : '/groups';
+      navigate(destination);
     } catch (err) {
       setError(err.response?.data?.error || 'Error al iniciar sesión');
     } finally {
@@ -27,6 +33,10 @@ export default function Login() {
   };
 
   const handleGoogleLogin = () => {
+    // Save returnTo in sessionStorage for Google OAuth callback
+    if (returnTo) {
+      sessionStorage.setItem('returnTo', returnTo);
+    }
     authAPI.googleLogin();
   };
 
@@ -118,7 +128,10 @@ export default function Login() {
 
         <p className="mt-6 text-center text-sm text-gray-600">
           ¿No tienes cuenta?{' '}
-          <Link to="/register" className="text-blue-600 hover:underline font-medium">
+          <Link
+            to={returnTo ? `/register?returnTo=${returnTo}` : '/register'}
+            className="text-blue-600 hover:underline font-medium"
+          >
             Regístrate aquí
           </Link>
         </p>

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 export default function Register() {
@@ -13,6 +13,10 @@ export default function Register() {
   const [loading, setLoading] = useState(false);
   const { register } = useAuth();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  // Get the return URL from query params
+  const returnTo = searchParams.get('returnTo');
 
   const handleChange = (e) => {
     setFormData({
@@ -43,7 +47,9 @@ export default function Register() {
         email: formData.email,
         password: formData.password,
       });
-      navigate('/groups');
+      // Redirect to returnTo if available, otherwise to /groups
+      const destination = returnTo ? decodeURIComponent(returnTo) : '/groups';
+      navigate(destination);
     } catch (err) {
       setError(err.response?.data?.error || 'Error al registrarse');
     } finally {
@@ -134,7 +140,10 @@ export default function Register() {
 
         <p className="mt-6 text-center text-sm text-gray-600">
           ¿Ya tienes cuenta?{' '}
-          <Link to="/login" className="text-blue-600 hover:underline font-medium">
+          <Link
+            to={returnTo ? `/login?returnTo=${returnTo}` : '/login'}
+            className="text-blue-600 hover:underline font-medium"
+          >
             Inicia sesión aquí
           </Link>
         </p>


### PR DESCRIPTION
When users click an invite link but aren't authenticated, they are now properly redirected back to the group after logging in or registering. This ensures a seamless onboarding experience for invited users.

Changes:
- ProtectedRoute now captures current location and passes it as returnTo query param
- Login/Register components check for returnTo and redirect accordingly after auth
- GoogleCallback retrieves returnTo from sessionStorage (preserved before OAuth redirect)
- Cross-linking between Login and Register pages preserves the returnTo parameter

Flow:
1. User clicks invite link (/group/abc123) while unauthenticated
2. ProtectedRoute redirects to /login?returnTo=/group/abc123
3. User logs in or registers (or uses Google OAuth)
4. After successful auth, user is redirected to /group/abc123
5. User can now join the group immediately