### PR TITLE
Fix Google Auth callback route not found error

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -110,7 +110,7 @@ export function googleCallback(req, res) {
     });
 
     // Redirect to frontend with token
-    res.redirect(`${process.env.FRONTEND_URL}/auth/callback?token=${token}`);
+    res.redirect(`${process.env.FRONTEND_URL}/oauth-callback?token=${token}`);
   } catch (error) {
     console.error('Google callback error:', error);
     res.redirect(`${process.env.FRONTEND_URL}/login?error=auth_failed`);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,7 +23,7 @@ function App() {
               <Route path="/" element={<Home />} />
               <Route path="/login" element={<Login />} />
               <Route path="/register" element={<Register />} />
-              <Route path="/auth/callback" element={<GoogleCallback />} />
+              <Route path="/oauth-callback" element={<GoogleCallback />} />
               <Route
                 path="/groups"
                 element={


### PR DESCRIPTION
El problema era que nginx estaba configurado para proxy todas las peticiones a /auth/* al backend, incluyendo /auth/callback que es una ruta del frontend. Esto causaba un 404 porque el backend no tiene esa ruta como endpoint API.

Cambios:
- Cambiar la redirección del backend de /auth/callback a /oauth-callback
- Actualizar la ruta en App.jsx para usar /oauth-callback
- Ahora la ruta no colisiona con la configuración de proxy de nginx

Fixes: Google Auth callback returning 404 "Ruta no encontrada"