### PR TITLE
Fix lost returnTo on invitation link login

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -109,8 +109,15 @@ export function googleCallback(req, res) {
       expiresIn: process.env.JWT_EXPIRES_IN,
     });
 
-    // Redirect to frontend with token
-    res.redirect(`${process.env.FRONTEND_URL}/oauth-callback?token=${token}`);
+    // Get returnTo from state parameter
+    const returnTo = req.query.state || '';
+
+    // Redirect to frontend with token and returnTo
+    let redirectUrl = `${process.env.FRONTEND_URL}/oauth-callback?token=${token}`;
+    if (returnTo) {
+      redirectUrl += `&returnTo=${encodeURIComponent(returnTo)}`;
+    }
+    res.redirect(redirectUrl);
   } catch (error) {
     console.error('Google callback error:', error);
     res.redirect(`${process.env.FRONTEND_URL}/login?error=auth_failed`);
@@ -127,8 +134,15 @@ export function metaCallback(req, res) {
       expiresIn: process.env.JWT_EXPIRES_IN,
     });
 
-    // Redirect to frontend with token
-    res.redirect(`${process.env.FRONTEND_URL}/oauth-callback-meta?token=${token}`);
+    // Get returnTo from state parameter
+    const returnTo = req.query.state || '';
+
+    // Redirect to frontend with token and returnTo
+    let redirectUrl = `${process.env.FRONTEND_URL}/oauth-callback-meta?token=${token}`;
+    if (returnTo) {
+      redirectUrl += `&returnTo=${encodeURIComponent(returnTo)}`;
+    }
+    res.redirect(redirectUrl);
   } catch (error) {
     console.error('Meta callback error:', error);
     res.redirect(`${process.env.FRONTEND_URL}/login?error=auth_failed`);

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -10,13 +10,15 @@ router.post('/register', register);
 router.post('/login', login);
 
 // Google OAuth
-router.get(
-  '/google',
+router.get('/google', (req, res, next) => {
+  // Capture returnTo from query string and pass it as state
+  const returnTo = req.query.returnTo || '';
   passport.authenticate('google', {
     scope: ['profile', 'email'],
     session: false,
-  })
-);
+    state: returnTo,
+  })(req, res, next);
+});
 
 router.get(
   '/google/callback',
@@ -25,13 +27,15 @@ router.get(
 );
 
 // Meta (Facebook/Instagram) OAuth
-router.get(
-  '/meta',
+router.get('/meta', (req, res, next) => {
+  // Capture returnTo from query string and pass it as state
+  const returnTo = req.query.returnTo || '';
   passport.authenticate('facebook', {
     scope: ['email'],
     session: false,
-  })
-);
+    state: returnTo,
+  })(req, res, next);
+});
 
 router.get(
   '/meta/callback',

--- a/frontend/src/pages/GoogleCallback.jsx
+++ b/frontend/src/pages/GoogleCallback.jsx
@@ -16,8 +16,12 @@ export default function GoogleCallback() {
         // Wait for user to be loaded before navigating
         const success = await handleGoogleCallback(token);
         if (success) {
-          // Check for returnTo in sessionStorage
-          const returnTo = sessionStorage.getItem('returnTo');
+          // Check for returnTo in URL first (from OAuth state), then sessionStorage as fallback
+          let returnTo = searchParams.get('returnTo');
+          if (!returnTo) {
+            returnTo = sessionStorage.getItem('returnTo');
+          }
+
           if (returnTo) {
             sessionStorage.removeItem('returnTo');
             navigate(decodeURIComponent(returnTo));

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -35,21 +35,23 @@ export default function Login() {
   const handleGoogleLogin = () => {
     // Clear any existing auth state before OAuth flow
     localStorage.removeItem('token');
-    // Save returnTo in sessionStorage for Google OAuth callback
+    // Save returnTo in sessionStorage as fallback for Google OAuth callback
     if (returnTo) {
       sessionStorage.setItem('returnTo', returnTo);
     }
-    authAPI.googleLogin();
+    // Pass returnTo as URL parameter to backend
+    authAPI.googleLogin(returnTo);
   };
 
   const handleMetaLogin = () => {
     // Clear any existing auth state before OAuth flow
     localStorage.removeItem('token');
-    // Save returnTo in sessionStorage for Meta OAuth callback
+    // Save returnTo in sessionStorage as fallback for Meta OAuth callback
     if (returnTo) {
       sessionStorage.setItem('returnTo', returnTo);
     }
-    authAPI.metaLogin();
+    // Pass returnTo as URL parameter to backend
+    authAPI.metaLogin(returnTo);
   };
 
   return (

--- a/frontend/src/pages/MetaCallback.jsx
+++ b/frontend/src/pages/MetaCallback.jsx
@@ -16,8 +16,12 @@ export default function MetaCallback() {
         // Wait for user to be loaded before navigating
         const success = await handleMetaCallback(token);
         if (success) {
-          // Check for returnTo in sessionStorage
-          const returnTo = sessionStorage.getItem('returnTo');
+          // Check for returnTo in URL first (from OAuth state), then sessionStorage as fallback
+          let returnTo = searchParams.get('returnTo');
+          if (!returnTo) {
+            returnTo = sessionStorage.getItem('returnTo');
+          }
+
           if (returnTo) {
             sessionStorage.removeItem('returnTo');
             navigate(decodeURIComponent(returnTo));

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -61,21 +61,23 @@ export default function Register() {
   const handleGoogleLogin = () => {
     // Clear any existing auth state before OAuth flow
     localStorage.removeItem('token');
-    // Save returnTo in sessionStorage for Google OAuth callback
+    // Save returnTo in sessionStorage as fallback for Google OAuth callback
     if (returnTo) {
       sessionStorage.setItem('returnTo', returnTo);
     }
-    authAPI.googleLogin();
+    // Pass returnTo as URL parameter to backend
+    authAPI.googleLogin(returnTo);
   };
 
   const handleMetaLogin = () => {
     // Clear any existing auth state before OAuth flow
     localStorage.removeItem('token');
-    // Save returnTo in sessionStorage for Meta OAuth callback
+    // Save returnTo in sessionStorage as fallback for Meta OAuth callback
     if (returnTo) {
       sessionStorage.setItem('returnTo', returnTo);
     }
-    authAPI.metaLogin();
+    // Pass returnTo as URL parameter to backend
+    authAPI.metaLogin(returnTo);
   };
 
   return (

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -41,12 +41,18 @@ export const authAPI = {
   register: (data) => api.post('/auth/register', data),
   login: (data) => api.post('/auth/login', data),
   getMe: () => api.get('/auth/me'),
-  googleLogin: () => {
-    const url = API_URL ? `${API_URL}/auth/google` : '/auth/google';
+  googleLogin: (returnTo) => {
+    let url = API_URL ? `${API_URL}/auth/google` : '/auth/google';
+    if (returnTo) {
+      url += `?returnTo=${encodeURIComponent(returnTo)}`;
+    }
     window.location.href = url;
   },
-  metaLogin: () => {
-    const url = API_URL ? `${API_URL}/auth/meta` : '/auth/meta';
+  metaLogin: (returnTo) => {
+    let url = API_URL ? `${API_URL}/auth/meta` : '/auth/meta';
+    if (returnTo) {
+      url += `?returnTo=${encodeURIComponent(returnTo)}`;
+    }
     window.location.href = url;
   },
 };


### PR DESCRIPTION
Cuando un usuario recibía un enlace de invitación y necesitaba hacer login con Google o Instagram, el parámetro returnTo se perdía después de la autenticación OAuth, lo que impedía redirigir al grupo invitado.

Solución implementada:
- Frontend pasa returnTo como parámetro URL al iniciar OAuth
- Backend captura returnTo y lo pasa como state al proveedor OAuth
- Backend incluye returnTo en la redirección final al frontend
- Callbacks del frontend leen returnTo desde URL (prioritario) y sessionStorage (fallback)

Archivos modificados:
- frontend/src/services/api.js: Modificar googleLogin/metaLogin para aceptar y pasar returnTo
- frontend/src/pages/Login.jsx: Pasar returnTo a las funciones OAuth
- frontend/src/pages/Register.jsx: Pasar returnTo a las funciones OAuth
- frontend/src/pages/GoogleCallback.jsx: Leer returnTo desde URL primero
- frontend/src/pages/MetaCallback.jsx: Leer returnTo desde URL primero
- backend/src/routes/auth.js: Capturar returnTo y pasarlo como state OAuth
- backend/src/controllers/authController.js: Incluir returnTo en redirecciones finales