### PR TITLE
Mostrar regalos comprados con tag 'comprado por otro/a'

### DIFF
--- a/backend/src/controllers/giftController.js
+++ b/backend/src/controllers/giftController.js
@@ -105,13 +105,12 @@ export async function getGroupWishlist(req, res) {
 
     // Get anonymous wishlist
     // Exclude: own gifts, deleted gifts
-    // Include: gifts not purchased OR purchased by current user
+    // Include: ALL gifts from other users (showing purchase status)
     const result = await query(
       `SELECT id, nombre, descripcion, url, image_url, created_at, comprador_id
        FROM gifts
        WHERE grupo_id = $1
        AND solicitante_id != $2
-       AND (comprador_id IS NULL OR comprador_id = $2)
        AND is_deleted_by_solicitante = false
        ORDER BY RANDOM()`,
       [grupoId, userId]

--- a/frontend/src/components/GiftCard.jsx
+++ b/frontend/src/components/GiftCard.jsx
@@ -3,13 +3,21 @@ import { useTheme } from '../context/ThemeContext';
 export default function GiftCard({ gift, onEdit, onDelete, onBuy, onUnbuy, showActions = true, currentUserId }) {
   const { theme } = useTheme();
   const isPurchasedByMe = gift.comprador_id && gift.comprador_id === currentUserId;
+  const isPurchasedByOther = gift.comprador_id && gift.comprador_id !== currentUserId;
 
   return (
-    <div className={`${theme.card} border rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow ${isPurchasedByMe ? 'relative' : ''}`}>
+    <div className={`${theme.card} border rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow ${(isPurchasedByMe || isPurchasedByOther) ? 'relative' : ''}`}>
       {isPurchasedByMe && (
         <div className="absolute top-2 right-2 z-10">
           <span className="bg-green-500 text-white text-xs font-semibold px-3 py-1 rounded-full shadow-lg">
             ✓ Comprado por mí
+          </span>
+        </div>
+      )}
+      {isPurchasedByOther && (
+        <div className="absolute top-2 right-2 z-10">
+          <span className="bg-orange-500 text-white text-xs font-semibold px-3 py-1 rounded-full shadow-lg">
+            ✓ Comprado por otro/a
           </span>
         </div>
       )}
@@ -18,7 +26,7 @@ export default function GiftCard({ gift, onEdit, onDelete, onBuy, onUnbuy, showA
         <img
           src={gift.image_url}
           alt={gift.nombre}
-          className={`w-full h-48 object-cover ${isPurchasedByMe ? 'opacity-75' : ''}`}
+          className={`w-full h-48 object-cover ${(isPurchasedByMe || isPurchasedByOther) ? 'opacity-75' : ''}`}
           onError={(e) => {
             e.target.style.display = 'none';
           }}
@@ -61,7 +69,7 @@ export default function GiftCard({ gift, onEdit, onDelete, onBuy, onUnbuy, showA
                 Eliminar
               </button>
             )}
-            {onBuy && (
+            {onBuy && !isPurchasedByOther && (
               <button
                 onClick={() => isPurchasedByMe ? onUnbuy(gift.id) : onBuy(gift.id)}
                 className={`${isPurchasedByMe ? 'bg-yellow-500 hover:bg-yellow-600' : theme.primary} text-white px-4 py-2 rounded font-medium w-full`}


### PR DESCRIPTION
Los regalos ya no desaparecen cuando son comprados por otra persona. Ahora se muestran con diferentes estados visuales:

Backend:
- Eliminada restricción que ocultaba regalos comprados por otros
- La wishlist ahora muestra TODOS los regalos del grupo (excepto propios)

Frontend:
- Tag verde "comprado por mí" para regalos que yo compré
- Tag naranja "comprado por otro/a" para regalos comprados por otros
- Sin tag para regalos disponibles
- Botón de compra solo visible si el regalo no está comprado por otro
- La persona que añadió el regalo no ve ningún tag (como antes)