### PR TITLE
Add group archive feature for creators

### DIFF
--- a/backend/src/migrations/005_add_archived_to_groups.sql
+++ b/backend/src/migrations/005_add_archived_to_groups.sql
@@ -1,0 +1,8 @@
+-- Migration 005: Add archived field to groups table
+-- This allows group creators to archive groups, preventing further modifications
+
+ALTER TABLE groups
+ADD COLUMN archived BOOLEAN DEFAULT FALSE NOT NULL;
+
+-- Add index for filtering archived groups efficiently
+CREATE INDEX idx_groups_archived ON groups(archived);

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -6,6 +6,8 @@ import {
   getUserGroups,
   getGroupMembers,
   updateGroup,
+  archiveGroup,
+  getArchivedGroups,
 } from '../controllers/groupController.js';
 import {
   createPairings,
@@ -21,10 +23,12 @@ router.use(requireAuth);
 // Group management
 router.post('/', createGroup);
 router.get('/my-groups', getUserGroups);
+router.get('/archived-groups', getArchivedGroups);
 router.get('/:codigoUrl', getGroupByCode);
 router.post('/:codigoUrl/join', joinGroup);
 router.get('/:grupoId/members', getGroupMembers);
 router.put('/:grupoId/update', updateGroup);
+router.put('/:grupoId/archive', archiveGroup);
 
 // Secret Santa (Amigo Invisible) routes
 router.post('/:grupoId/secret-santa/create-pairings', createPairings);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import GoogleCallback from './pages/GoogleCallback';
 import MetaCallback from './pages/MetaCallback';
 import VerifyEmail from './pages/VerifyEmail';
 import Groups from './pages/Groups';
+import ArchivedGroups from './pages/ArchivedGroups';
 import GroupDetail from './pages/GroupDetail';
 import TermsOfService from './pages/TermsOfService';
 import PrivacyPolicy from './pages/PrivacyPolicy';
@@ -35,6 +36,14 @@ function App() {
                 element={
                   <ProtectedRoute>
                     <Groups />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/archived-groups"
+                element={
+                  <ProtectedRoute>
+                    <ArchivedGroups />
                   </ProtectedRoute>
                 }
               />

--- a/frontend/src/pages/ArchivedGroups.jsx
+++ b/frontend/src/pages/ArchivedGroups.jsx
@@ -1,0 +1,96 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { groupAPI } from '../services/api';
+import { useTheme } from '../context/ThemeContext';
+
+export default function ArchivedGroups() {
+  const [groups, setGroups] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const { theme } = useTheme();
+
+  useEffect(() => {
+    loadArchivedGroups();
+  }, []);
+
+  const loadArchivedGroups = async () => {
+    try {
+      const response = await groupAPI.getArchivedGroups();
+      setGroups(response.data.groups);
+    } catch (error) {
+      console.error('Failed to load archived groups:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+          <p className="mt-4 text-gray-600">Cargando...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center mb-8">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Grupos Archivados</h1>
+            <p className="text-gray-600 mt-2">
+              Estos grupos están archivados y no se pueden modificar
+            </p>
+          </div>
+          <Link
+            to="/groups"
+            className="text-blue-600 hover:text-blue-800 underline"
+          >
+            ← Volver a Mis Grupos
+          </Link>
+        </div>
+
+        {groups.length === 0 ? (
+          <div className="text-center py-12">
+            <div className="text-6xl mb-4">📦</div>
+            <p className="text-gray-600 mb-4">No tienes grupos archivados</p>
+            <Link
+              to="/groups"
+              className={`${theme.primary} text-white px-6 py-3 rounded-md font-medium inline-block`}
+            >
+              Ir a Mis Grupos
+            </Link>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {groups.map((group) => (
+              <Link
+                key={group.id}
+                to={`/group/${group.codigo_url}`}
+                className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow border-2 border-yellow-400"
+              >
+                <div className="flex items-start justify-between mb-2">
+                  <h3 className="text-xl font-bold text-gray-900">{group.nombre_grupo}</h3>
+                  <span className="bg-yellow-100 text-yellow-800 text-xs font-medium px-2 py-1 rounded">
+                    Archivado
+                  </span>
+                </div>
+                <div className="space-y-1 text-sm text-gray-600">
+                  <p>{group.tipo_celebracion}</p>
+                  <p className="text-purple-600 font-medium">
+                    {group.game_mode === 'Amigo Invisible' ? '🎭 Amigo Invisible' : '🎁 Lista de Deseos'}
+                  </p>
+                  <p>Fecha: {new Date(group.fecha_inicio).toLocaleDateString('es-ES')}</p>
+                  <p>Miembros: {group.member_count}</p>
+                  <p className="text-xs text-gray-500 italic">Creado por: {group.creator_name}</p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/GroupDetail.jsx
+++ b/frontend/src/pages/GroupDetail.jsx
@@ -267,6 +267,17 @@ export default function GroupDetail() {
     }
   };
 
+  const handleArchiveGroup = async () => {
+    if (!confirm('¿Estás seguro de archivar este grupo? Una vez archivado, no se podrán hacer más cambios (añadir o modificar regalos).')) return;
+    try {
+      await groupAPI.archive(group.id);
+      alert('Grupo archivado exitosamente');
+      navigate('/groups');
+    } catch (error) {
+      alert(error.response?.data?.error || 'Error al archivar grupo');
+    }
+  };
+
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -363,13 +374,26 @@ export default function GroupDetail() {
                   {loadingPairings ? 'Realizando sorteo...' : '🎭 Realizar Sorteo'}
                 </button>
               )}
-              {user && user.id === group.creator_id && (
-                <button
-                  onClick={handleEditGroup}
-                  className={`${theme.primary} text-white px-4 py-2 rounded-md text-sm transition-colors`}
-                >
-                  ✏️ Editar Grupo
-                </button>
+              {user && user.id === group.creator_id && !group.archived && (
+                <>
+                  <button
+                    onClick={handleEditGroup}
+                    className={`${theme.primary} text-white px-4 py-2 rounded-md text-sm transition-colors`}
+                  >
+                    ✏️ Editar Grupo
+                  </button>
+                  <button
+                    onClick={handleArchiveGroup}
+                    className="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md text-sm transition-colors"
+                  >
+                    📦 Archivar Grupo
+                  </button>
+                </>
+              )}
+              {group.archived && (
+                <div className="bg-yellow-100 border border-yellow-400 text-yellow-800 px-4 py-2 rounded-md text-sm font-medium">
+                  📦 Grupo Archivado
+                </div>
               )}
               <button
                 onClick={copyInviteLink}
@@ -476,8 +500,8 @@ export default function GroupDetail() {
                       <GiftCard
                         key={gift.id}
                         gift={gift}
-                        onBuy={handleBuyGift}
-                        onUnbuy={handleUnbuyGift}
+                        onBuy={!group.archived ? handleBuyGift : undefined}
+                        onUnbuy={!group.archived ? handleUnbuyGift : undefined}
                         currentUserId={user?.id}
                         isWishlistView={true}
                       />
@@ -492,16 +516,18 @@ export default function GroupDetail() {
                 <EmailVerificationBanner user={user} />
                 <div className="flex justify-between items-center mb-4">
                   <h2 className="text-2xl font-bold text-gray-900">Mis Regalos</h2>
-                  <button
-                    onClick={() => {
-                      setEditingGift(null);
-                      setFormData({ nombre: '', descripcion: '', url: '' });
-                      setShowAddGift(true);
-                    }}
-                    className={`${theme.primary} text-white px-4 py-2 rounded-md font-medium`}
-                  >
-                    + Añadir Regalo
-                  </button>
+                  {!group.archived && (
+                    <button
+                      onClick={() => {
+                        setEditingGift(null);
+                        setFormData({ nombre: '', descripcion: '', url: '' });
+                        setShowAddGift(true);
+                      }}
+                      className={`${theme.primary} text-white px-4 py-2 rounded-md font-medium`}
+                    >
+                      + Añadir Regalo
+                    </button>
+                  )}
                 </div>
 
                 {myGifts.length === 0 ? (
@@ -512,8 +538,8 @@ export default function GroupDetail() {
                       <GiftCard
                         key={gift.id}
                         gift={gift}
-                        onEdit={handleEditGift}
-                        onDelete={handleDeleteGift}
+                        onEdit={!group.archived ? handleEditGift : undefined}
+                        onDelete={!group.archived ? handleDeleteGift : undefined}
                         currentUserId={user?.id}
                       />
                     ))}

--- a/frontend/src/pages/Groups.jsx
+++ b/frontend/src/pages/Groups.jsx
@@ -104,39 +104,50 @@ export default function Groups() {
             </button>
           </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {groups.map((group) => (
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {groups.map((group) => (
+                <Link
+                  key={group.id}
+                  to={`/group/${group.codigo_url}`}
+                  className={`${theme.card} border rounded-lg p-6 hover:shadow-lg transition-shadow`}
+                >
+                  <div className="flex items-center justify-between mb-2">
+                    <h2 className="text-xl font-semibold text-gray-900">{group.nombre_grupo}</h2>
+                    <span className={`text-2xl`}>
+                      {group.tipo_celebracion === 'Navidad' && '🎄'}
+                      {group.tipo_celebracion === 'Reyes Magos' && '👑'}
+                      {group.tipo_celebracion === 'Boda' && '💒'}
+                      {group.tipo_celebracion === 'Cumpleaños' && '🎂'}
+                      {group.tipo_celebracion === 'Otro' && '🎁'}
+                    </span>
+                  </div>
+                  <p className="text-gray-600 text-sm mb-2">{group.tipo_celebracion}</p>
+                  <p className="text-gray-500 text-sm">
+                    Fecha: {new Date(group.fecha_inicio).toLocaleDateString('es-ES')}
+                  </p>
+                  <p className="text-gray-500 text-sm">
+                    Miembros:{' '}
+                    <button
+                      onClick={(e) => handleShowMembers(group, e)}
+                      className="text-blue-600 hover:text-blue-800 underline"
+                    >
+                      {group.member_count}
+                    </button>
+                  </p>
+                </Link>
+              ))}
+            </div>
+            <div className="mt-8 text-center border-t pt-6">
               <Link
-                key={group.id}
-                to={`/group/${group.codigo_url}`}
-                className={`${theme.card} border rounded-lg p-6 hover:shadow-lg transition-shadow`}
+                to="/archived-groups"
+                className="text-gray-600 hover:text-gray-800 underline text-sm flex items-center justify-center gap-2"
               >
-                <div className="flex items-center justify-between mb-2">
-                  <h2 className="text-xl font-semibold text-gray-900">{group.nombre_grupo}</h2>
-                  <span className={`text-2xl`}>
-                    {group.tipo_celebracion === 'Navidad' && '🎄'}
-                    {group.tipo_celebracion === 'Reyes Magos' && '👑'}
-                    {group.tipo_celebracion === 'Boda' && '💒'}
-                    {group.tipo_celebracion === 'Cumpleaños' && '🎂'}
-                    {group.tipo_celebracion === 'Otro' && '🎁'}
-                  </span>
-                </div>
-                <p className="text-gray-600 text-sm mb-2">{group.tipo_celebracion}</p>
-                <p className="text-gray-500 text-sm">
-                  Fecha: {new Date(group.fecha_inicio).toLocaleDateString('es-ES')}
-                </p>
-                <p className="text-gray-500 text-sm">
-                  Miembros:{' '}
-                  <button
-                    onClick={(e) => handleShowMembers(group, e)}
-                    className="text-blue-600 hover:text-blue-800 underline"
-                  >
-                    {group.member_count}
-                  </button>
-                </p>
+                <span>📦</span>
+                Ver Grupos Archivados
               </Link>
-            ))}
-          </div>
+            </div>
+          </>
         )}
 
         {/* Create Group Modal */}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -63,10 +63,12 @@ export const authAPI = {
 export const groupAPI = {
   create: (data) => api.post('/api/groups', data),
   getMyGroups: () => api.get('/api/groups/my-groups'),
+  getArchivedGroups: () => api.get('/api/groups/archived-groups'),
   getByCode: (codigoUrl) => api.get(`/api/groups/${codigoUrl}`),
   join: (codigoUrl) => api.post(`/api/groups/${codigoUrl}/join`),
   getMembers: (grupoId) => api.get(`/api/groups/${grupoId}/members`),
   update: (grupoId, data) => api.put(`/api/groups/${grupoId}/update`, data),
+  archive: (grupoId) => api.put(`/api/groups/${grupoId}/archive`),
   // Secret Santa endpoints
   createPairings: (grupoId) => api.post(`/api/groups/${grupoId}/secret-santa/create-pairings`),
   getMyAssignment: (grupoId) => api.get(`/api/groups/${grupoId}/secret-santa/my-assignment`),


### PR DESCRIPTION
Backend:
- Añadir migración 005 para agregar campo 'archived' a tabla groups
- Implementar endpoint PUT /api/groups/:grupoId/archive (solo creador)
- Implementar endpoint GET /api/groups/archived-groups
- Filtrar grupos archivados de getUserGroups
- Bloquear modificación de grupos archivados en updateGroup
- Bloquear creación/modificación/eliminación de regalos en grupos archivados
- Bloquear marcar/desmarcar regalos como comprados en grupos archivados

Frontend:
- Añadir métodos archive() y getArchivedGroups() al API service
- Crear nueva página ArchivedGroups en /archived-groups
- Añadir botón "Archivar Grupo" en GroupDetail (solo para creador)
- Mostrar badge "Grupo Archivado" cuando grupo está archivado
- Deshabilitar botones de añadir/editar/eliminar regalos en grupos archivados
- Deshabilitar botones de comprar/desmarcar en grupos archivados
- Añadir enlace "Ver Grupos Archivados" al final de página Groups
- Añadir ruta protegida /archived-groups en App.jsx

Funcionalidad:
- Solo el creador del grupo puede archivar un grupo
- Una vez archivado, no se pueden hacer cambios (regalos ni configuración)
- Los grupos archivados aparecen en página separada accesible desde /groups
- Los grupos archivados se filtran de la lista principal de grupos activos